### PR TITLE
fix: order default interact values

### DIFF
--- a/src/poincare/simulator.py
+++ b/src/poincare/simulator.py
@@ -227,15 +227,17 @@ class Simulator:
                 case numbers.Real() as default:
                     if v == 0:
                         v = 1
+                    min, max = sorted((default / 10, v * 10))
                     widget = ipywidgets.FloatSlider(
                         default,
-                        min=default / 10,
-                        max=v * 10,
-                        step=0.1 * v,
+                        min=min,
+                        max=max,
+                        step=0.1 * abs(v),
                     )
                 case pint.Quantity(magnitude=v, units=unit):
+                    min, max = sorted((v / 10, v * 10))
                     widget = ipywidgets.FloatSlider(
-                        v, min=v / 10, max=v * 10, step=0.1 * v
+                        v, min=min, max=max, step=0.1 * abs(v)
                     )
                 case (min, max, step):
                     v = self.compiled.mapper[k]

--- a/src/poincare/tests/test_interact.py
+++ b/src/poincare/tests/test_interact.py
@@ -1,0 +1,15 @@
+from .. import Simulator
+from ..types import Parameter, System, Variable, assign, initial
+
+
+def test_negative_params():
+    class Model(System):
+        x: Variable = initial(default=1)
+
+        k: Parameter = assign(default=-1)
+
+        eq = x.derive() << k * x
+
+    sim = Simulator(Model)
+    t = range(3)
+    sim.interact(save_at=t)


### PR DESCRIPTION
In this PR order the default values of the min and max of the float slider.